### PR TITLE
Add tropical attention adapter for multi-head interface

### DIFF
--- a/tropical/TropicalAttention.py
+++ b/tropical/TropicalAttention.py
@@ -9,14 +9,15 @@ class TropicalLinear(nn.Module):
         self.input_dim = input_dim
         self.output_dim = output_dim
         self.W = nn.Parameter(torch.randn(output_dim, input_dim))
-    
+
     def forward(self, x):
         x_expanded = x.unsqueeze(-2)
         W_expanded = self.W.unsqueeze(0)
-        Wx = x_expanded + W_expanded  
+        Wx = x_expanded + W_expanded
         y, _ = torch.max(Wx, dim=-1)
         return y
-    
+
+
 class TropicalAttention(nn.Module):
     def __init__(self, d_model, n_heads, device, tropical_proj=True, tropical_norm=False, symmetric=True):
         super(TropicalAttention, self).__init__()
@@ -26,7 +27,7 @@ class TropicalAttention(nn.Module):
         self.tropical_proj = tropical_proj
         self.tropical_norm = tropical_norm
         self.symmetric = symmetric
-        
+
         # Linear layers without bias
         self.out = nn.Linear(d_model, d_model, bias=False)
 
@@ -42,9 +43,9 @@ class TropicalAttention(nn.Module):
     def normalize_tropical(self, x):
         return x - self.lambda_param
 
-    def forward(self, x):
+    def forward(self, x, attn_mask=None):
         batch_size, seq_len, _ = x.size()
-        
+
         if self.tropical_norm:
             # Apply ReLU and log1p in a single pass before linear transformation
             q = self.normalize_tropical(torch.log1p(F.relu(x)))
@@ -54,12 +55,12 @@ class TropicalAttention(nn.Module):
             q = torch.log1p(F.relu(x))
             k = torch.log1p(F.relu(x))
             v = torch.log1p(F.relu(x))
-        
+
         # Reshape and permute for multi-head attention
         q = q.reshape(batch_size, seq_len, self.n_heads, self.d_k).permute(0, 2, 1, 3)  # [B, H, S, D]
         k = k.reshape(batch_size, seq_len, self.n_heads, self.d_k).permute(0, 2, 1, 3)
         v = v.reshape(batch_size, seq_len, self.n_heads, self.d_k).permute(0, 2, 1, 3)
-        
+
         # Merge batch and heads for parallel computation
         B = batch_size * self.n_heads
         q = q.reshape(B, seq_len, self.d_k)  # [B, S, D]
@@ -86,16 +87,39 @@ class TropicalAttention(nn.Module):
             min_diff = diff.amin(dim=-1)             # [B, S, S]
             n = q.size(-1)
             attn_scores = - (sum_diff - n * min_diff)
-        
+
+        query_mask_rows = None
+        if attn_mask is not None:
+            attn_mask = attn_mask.to(dtype=torch.bool)
+            if attn_mask.dim() == 2:
+                if attn_mask.size(1) != seq_len:
+                    raise ValueError("Mask sequence dimension does not match input length")
+                attn_mask = attn_mask.unsqueeze(1).expand(-1, seq_len, -1)
+            elif attn_mask.dim() != 3:
+                raise ValueError("Attention mask must be either 2D or 3D")
+            if attn_mask.size(-1) != seq_len or attn_mask.size(-2) != seq_len:
+                raise ValueError("Attention mask dimensions must match sequence length")
+
+            query_mask_rows = attn_mask.all(dim=-1)
+            attn_mask = attn_mask.unsqueeze(1).expand(batch_size, self.n_heads, seq_len, seq_len)
+            attn_mask = attn_mask.reshape(B, seq_len, seq_len)
+            mask_value = torch.finfo(attn_scores.dtype).min
+            attn_scores = attn_scores.masked_fill(attn_mask, mask_value)
+
         # Compute context using tropical multiplication and aggregation
         sum_sv = attn_scores.unsqueeze(-1) + v.unsqueeze(1)  # [B, S, S, D]
         context = sum_sv.max(dim=2).values  # [B, S, D]
-        
+
         # Reshape context back to [batch_size, seq_len, d_model]
         context = context.reshape(batch_size, self.n_heads, seq_len, self.d_k).permute(0, 2, 1, 3).reshape(batch_size, seq_len, -1)
-        
+
+        if query_mask_rows is not None:
+            context = context.masked_fill(query_mask_rows.unsqueeze(-1), 0.0)
+
         # Apply the output linear layer after exponentiation
         context = torch.expm1(context)
         output = self.out(context)
-        
+
+        attn_scores = attn_scores.reshape(batch_size, self.n_heads, seq_len, seq_len)
+
         return output, attn_scores

--- a/tropical/TropicalMultiHeadAttention.py
+++ b/tropical/TropicalMultiHeadAttention.py
@@ -1,0 +1,96 @@
+import torch
+import torch.nn as nn
+
+from .TropicalAttention import TropicalAttention
+
+
+class TropicalMultiHeadAttention(nn.Module):
+    """Adapter exposing a (query, context, mask) interface around :class:`TropicalAttention`."""
+
+    def __init__(
+        self,
+        n_heads,
+        input_dim,
+        embed_dim=None,
+        device=None,
+        tropical_proj=True,
+        tropical_norm=False,
+        symmetric=True,
+    ):
+        super().__init__()
+
+        if embed_dim is None:
+            embed_dim = input_dim
+
+        if embed_dim != input_dim:
+            raise ValueError(
+                "TropicalMultiHeadAttention currently assumes input_dim == embed_dim for self-attention replacements."
+            )
+
+        if device is None:
+            device = torch.device("cpu")
+        else:
+            device = torch.device(device)
+
+        self.n_heads = n_heads
+        self.input_dim = input_dim
+        self.embed_dim = embed_dim
+
+        self.attention = TropicalAttention(
+            d_model=embed_dim,
+            n_heads=n_heads,
+            device=device,
+            tropical_proj=tropical_proj,
+            tropical_norm=tropical_norm,
+            symmetric=symmetric,
+        )
+
+        self.last_attention_scores = None
+
+    def forward(self, inputs):
+        if not isinstance(inputs, (list, tuple)) or len(inputs) != 3:
+            raise ValueError("TropicalMultiHeadAttention expects a tuple of (query, context, mask).")
+
+        q, h, mask = inputs
+
+        if h is None:
+            h = q
+        if q is None:
+            q = h
+
+        if q is None or h is None:
+            raise ValueError("Both query and context tensors must be provided.")
+
+        if q.dim() != 3 or h.dim() != 3:
+            raise ValueError("Query and context must be 3D tensors of shape [batch, sequence, features].")
+
+        if q.size(0) != h.size(0):
+            raise ValueError("Query and context must share the same batch size.")
+
+        if q.size(-1) != self.embed_dim or h.size(-1) != self.embed_dim:
+            raise ValueError("Last dimension of query/context does not match the configured embedding size.")
+
+        if q.size(1) != h.size(1):
+            raise NotImplementedError(
+                "TropicalMultiHeadAttention currently supports self-attention only (query and context lengths must match)."
+            )
+
+        attn_mask = None
+        processed_mask = None
+        if mask is not None:
+            processed_mask = mask.bool()
+            attn_mask = processed_mask
+            if attn_mask.dim() == 2:
+                if attn_mask.size(1) != h.size(1):
+                    raise ValueError("Mask width must equal the sequence length for self-attention.")
+                attn_mask = attn_mask.unsqueeze(1).expand(-1, h.size(1), -1)
+            elif attn_mask.dim() != 3:
+                raise ValueError("Mask tensor must have 2 or 3 dimensions.")
+
+            if attn_mask.size(-1) != h.size(1) or attn_mask.size(-2) != h.size(1):
+                raise ValueError("Mask dimensions must be square and match the sequence length for self-attention.")
+
+        output, attn_scores = self.attention(h, attn_mask=attn_mask)
+        self.last_attention_scores = attn_scores
+
+        return output, None, processed_mask


### PR DESCRIPTION
## Summary
- add mask-aware forward path to TropicalAttention and expose per-head attention scores
- introduce TropicalMultiHeadAttention wrapper exposing the (query, context, mask) API used across LaDe experiments

## Testing
- python -m compileall tropical

------
https://chatgpt.com/codex/tasks/task_e_68c84bc9867083238e52f8e960b04ee6