### PR TITLE
Add HPC workflow for tropical CPRoute training

### DIFF
--- a/route_prediction/algorithm/cproute/train.py
+++ b/route_prediction/algorithm/cproute/train.py
@@ -2,7 +2,7 @@
 import torch
 import torch.nn.functional as F
 from tqdm import tqdm
-from algorithm.cproute_0303.Dataset import CPRouteDataset
+from algorithm.cproute.Dataset import CPRouteDataset
 from utils.util import  to_device, run, get_nonzeros_nrl, dict_merge
 
 def process_batch(batch, model, device, params):

--- a/route_prediction/readme.md
+++ b/route_prediction/readme.md
@@ -27,10 +27,37 @@ python data/dataset_pickup.py
 ```
 The constructed dataset will be stored in /data/dataset/. 
 
-3.2 model training  
+3.2 model training
 ```shell
 python run.py
 ```
+
+### Tropical CPRoute with tropical attention on HPC
+
+To run the CPRoute model variant that leverages the tropical multi-head attention
+module on a high-performance computing cluster, submit the batch script located
+at `scripts/tropical_cproute_job.sh`. The script performs the following steps:
+
+1. Creates (or reuses) an isolated Python virtual environment.
+2. Installs the task requirements together with the `huggingface_hub` package.
+3. Downloads the `pickup_yt_0614_dataset_change` splits via
+   `scripts/download_pickup_dataset.py` (set `SKIP_DATA_DOWNLOAD=1` to reuse
+   existing files).
+4. Executes `run.py` with arguments configured to enable tropical attention in
+   CPRoute.
+
+You can customize common options via environment variables before calling
+`sbatch`, for example:
+
+```bash
+export NUM_EPOCH=40
+export HF_TOKEN="<your huggingface token>"
+sbatch scripts/tropical_cproute_job.sh
+```
+
+The dataset download script accepts additional parameters (repository id,
+prefix, or archive filename) through the batch script variables, allowing you to
+adapt the workflow to mirrored storage or alternative dataset locations.
 
 
 ## Citing

--- a/route_prediction/scripts/download_pickup_dataset.py
+++ b/route_prediction/scripts/download_pickup_dataset.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Utility for downloading the CPRoute dataset splits from Hugging Face Hub.
+
+The script downloads the pre-processed numpy files used by the route prediction
+tasks.  It prefers individual ``train.npy``, ``val.npy`` and ``test.npy`` files
+but can fall back to extracting an archive when the individual splits are not
+directly accessible.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import tarfile
+import zipfile
+from pathlib import Path
+from typing import Iterable, List
+
+from huggingface_hub import hf_hub_download
+from huggingface_hub.utils import HfHubHTTPError
+
+
+def _extract_archive(archive_path: Path, output_dir: Path) -> bool:
+    """Extract ``archive_path`` into ``output_dir`` when the format is supported."""
+
+    if tarfile.is_tarfile(archive_path):
+        with tarfile.open(archive_path, mode="r:*") as tar:
+            tar.extractall(output_dir)
+        return True
+
+    if zipfile.is_zipfile(archive_path):
+        with zipfile.ZipFile(archive_path, mode="r") as zf:
+            zf.extractall(output_dir)
+        return True
+
+    return False
+
+
+def _download_file(
+    repo_id: str,
+    filename: str,
+    output_dir: Path,
+    token: str | None,
+) -> Path:
+    """Download ``filename`` from ``repo_id`` and return the local file path."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    downloaded = hf_hub_download(
+        repo_id=repo_id,
+        filename=filename,
+        local_dir=output_dir,
+        local_dir_use_symlinks=False,
+        token=token,
+    )
+    return Path(downloaded)
+
+
+def _split_filenames(
+    repo_prefix: str,
+    dataset: str,
+    splits: Iterable[str],
+) -> List[str]:
+    return ["/".join(filter(None, [repo_prefix, dataset, f"{split}.npy"])) for split in splits]
+
+
+def _archive_candidates(repo_prefix: str, dataset: str, override: str | None) -> List[str]:
+    if override:
+        return ["/".join(filter(None, [repo_prefix, override]))]
+    candidates = [
+        f"{dataset}.tar.gz",
+        f"{dataset}.tgz",
+        f"{dataset}.zip",
+    ]
+    return ["/".join(filter(None, [repo_prefix, candidate])) for candidate in candidates]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Download CPRoute dataset splits from Hugging Face Hub")
+    parser.add_argument(
+        "--repo-id",
+        default="Cainiao-AI/LaDe-P",
+        help="Hugging Face repository identifier containing the dataset.",
+    )
+    parser.add_argument(
+        "--repo-prefix",
+        default="route_prediction/dataset",
+        help="Repository sub-directory that stores the dataset artifacts.",
+    )
+    parser.add_argument(
+        "--dataset",
+        required=True,
+        help="Name of the dataset folder inside the repository.",
+    )
+    parser.add_argument(
+        "--splits",
+        nargs="+",
+        default=("train", "val", "test"),
+        help="Dataset splits that should be downloaded.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Local directory where the dataset will be stored.",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("HF_TOKEN"),
+        help="Optional Hugging Face token for private or rate-limited downloads.",
+    )
+    parser.add_argument(
+        "--archive-filename",
+        default=None,
+        help=(
+            "Optional archive name (relative to --repo-prefix) that should be used "
+            "when the individual splits are unavailable."
+        ),
+    )
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir).expanduser().resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    requested_splits = list(args.splits)
+    split_files = _split_filenames(args.repo_prefix, args.dataset, requested_splits)
+    missing_splits: List[str] = []
+
+    for split, remote_file in zip(requested_splits, split_files):
+        local_file = output_dir / f"{split}.npy"
+        if local_file.exists():
+            print(f"[download] Found existing {local_file}, skipping download.")
+            continue
+        print(f"[download] Fetching {remote_file} from {args.repo_id}...")
+        try:
+            _download_file(args.repo_id, remote_file, output_dir, args.token)
+        except HfHubHTTPError as err:
+            print(
+                f"[download] Unable to fetch split '{split}' directly ({err}). "
+                "Will attempt archive fallbacks."
+            )
+            missing_splits.append(split)
+        else:
+            print(f"[download] Saved split '{split}' to {local_file}.")
+
+    if not missing_splits:
+        return
+
+    archive_paths = _archive_candidates(args.repo_prefix, args.dataset, args.archive_filename)
+    for archive in archive_paths:
+        print(f"[download] Attempting archive download: {archive}")
+        try:
+            archive_path = _download_file(args.repo_id, archive, output_dir, args.token)
+        except HfHubHTTPError as err:
+            print(f"[download] Archive {archive} unavailable ({err}).")
+            continue
+
+        if not _extract_archive(archive_path, output_dir):
+            print(f"[download] File {archive_path} is not a supported archive format.")
+            continue
+
+        print(f"[download] Extracted archive {archive_path}.")
+        break
+    else:  # pragma: no cover - executed when no archive succeeded
+        raise SystemExit(
+            "Unable to download required dataset splits. Provide --archive-filename "
+            "or verify the repository structure."
+        )
+
+    missing_after_extract = [
+        split for split in missing_splits if not (output_dir / f"{split}.npy").exists()
+    ]
+    if missing_after_extract:
+        raise SystemExit(
+            "Missing splits after archive extraction: "
+            + ", ".join(missing_after_extract)
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/route_prediction/scripts/tropical_cproute_job.sh
+++ b/route_prediction/scripts/tropical_cproute_job.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+#SBATCH --job-name=tropical_cproute
+#SBATCH --gres=gpu:1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=32G
+#SBATCH --time=24:00:00
+#SBATCH --output=%x_%j.out
+#SBATCH --error=%x_%j.err
+
+set -euo pipefail
+
+export PYTHONUNBUFFERED=1
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_ROOT=${PROJECT_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}
+ROUTE_PRED_DIR="$PROJECT_ROOT/route_prediction"
+LOG_DIR=${LOG_DIR:-"$ROUTE_PRED_DIR/logs"}
+VENV_DIR=${VENV_DIR:-"$PROJECT_ROOT/.venvs/tropical_cproute"}
+PYTHON_BIN=${PYTHON_BIN:-python3}
+DATASET_NAME=${DATASET_NAME:-pickup_yt_0614_dataset_change}
+HF_REPO_ID=${HF_REPO_ID:-Cainiao-AI/LaDe-P}
+HF_REPO_PREFIX=${HF_REPO_PREFIX:-route_prediction/dataset}
+BATCH_SIZE=${BATCH_SIZE:-64}
+NUM_EPOCH=${NUM_EPOCH:-30}
+HIDDEN_SIZE=${HIDDEN_SIZE:-128}
+SORT_X_SIZE=${SORT_X_SIZE:-8}
+LEARNING_RATE=${LEARNING_RATE:-0.001}
+WEIGHT_DECAY=${WEIGHT_DECAY:-1e-5}
+EARLY_STOP=${EARLY_STOP:-5}
+
+mkdir -p "$LOG_DIR"
+
+echo "[$(date)] Starting tropical CPRoute job"
+echo "PROJECT_ROOT=$PROJECT_ROOT"
+echo "ROUTE_PRED_DIR=$ROUTE_PRED_DIR"
+echo "VENV_DIR=$VENV_DIR"
+
+cd "$PROJECT_ROOT"
+
+if [[ ! -d "$VENV_DIR" ]]; then
+    echo "[$(date)] Creating virtual environment at $VENV_DIR"
+    "$PYTHON_BIN" -m venv "$VENV_DIR"
+fi
+
+source "$VENV_DIR/bin/activate"
+
+python -m pip install --upgrade pip
+python -m pip install -r "$ROUTE_PRED_DIR/requirements.txt"
+python -m pip install "huggingface_hub==0.34.5"
+
+DATASET_DIR="$ROUTE_PRED_DIR/data/dataset/$DATASET_NAME"
+if [[ "${SKIP_DATA_DOWNLOAD:-0}" != "1" ]]; then
+    echo "[$(date)] Downloading dataset splits into $DATASET_DIR"
+    python "$ROUTE_PRED_DIR/scripts/download_pickup_dataset.py" \
+        --dataset "$DATASET_NAME" \
+        --output-dir "$DATASET_DIR" \
+        --repo-id "$HF_REPO_ID" \
+        --repo-prefix "$HF_REPO_PREFIX"
+else
+    echo "[$(date)] Skipping dataset download as requested."
+fi
+
+extra_args=()
+if [[ -n "${TROPICAL_KWARGS_JSON:-}" ]]; then
+    extra_args+=(--tropical_attention_kwargs "$TROPICAL_KWARGS_JSON")
+fi
+if [[ -n "${ADDITIONAL_RUN_ARGS:-}" ]]; then
+    # shellcheck disable=SC2206
+    additional_args=( ${ADDITIONAL_RUN_ARGS} )
+    extra_args+=("${additional_args[@]}")
+fi
+
+echo "[$(date)] Launching CPRoute training with tropical attention"
+cmd=(
+    python "$ROUTE_PRED_DIR/run.py"
+    --model cproute
+    --dataset "$DATASET_NAME"
+    --batch_size "$BATCH_SIZE"
+    --num_epoch "$NUM_EPOCH"
+    --hidden_size "$HIDDEN_SIZE"
+    --sort_x_size "$SORT_X_SIZE"
+    --lr "$LEARNING_RATE"
+    --wd "$WEIGHT_DECAY"
+    --early_stop "$EARLY_STOP"
+    --use_tropical_attention
+)
+if ((${#extra_args[@]})); then
+    cmd+=("${extra_args[@]}")
+fi
+"${cmd[@]}"
+
+echo "[$(date)] Tropical CPRoute job completed"


### PR DESCRIPTION
## Summary
- refactor `route_prediction/run.py` to accept CLI arguments for single model runs, tropical attention, and dataset selection while keeping the default sweep available
- fix the CPRoute training import and add scripts for Hugging Face dataset downloads and an HPC batch job that provisions a venv and trains with tropical attention
- document the new workflow in `route_prediction/readme.md`

## Testing
- python -m py_compile route_prediction/run.py
- python -m py_compile route_prediction/scripts/download_pickup_dataset.py
- bash -n route_prediction/scripts/tropical_cproute_job.sh
- python route_prediction/scripts/download_pickup_dataset.py --help

------
https://chatgpt.com/codex/tasks/task_e_68c85f3b2ca48323a0b2d997fa9c4853