### PR TITLE
Fix HF dataset downloads

### DIFF
--- a/route_prediction/readme.md
+++ b/route_prediction/readme.md
@@ -40,9 +40,9 @@ at `scripts/tropical_cproute_job.sh`. The script performs the following steps:
 
 1. Creates (or reuses) an isolated Python virtual environment.
 2. Installs the task requirements together with the `huggingface_hub` package.
-3. Downloads the `pickup_yt_0614_dataset_change` splits via
-   `scripts/download_pickup_dataset.py` (set `SKIP_DATA_DOWNLOAD=1` to reuse
-   existing files).
+3. Downloads the `pickup_yt_0614_dataset_change` splits from the Hugging Face
+   dataset repository via `scripts/download_pickup_dataset.py --repo-type
+   dataset` (set `SKIP_DATA_DOWNLOAD=1` to reuse existing files).
 4. Executes `run.py` with arguments configured to enable tropical attention in
    CPRoute.
 
@@ -52,8 +52,13 @@ You can customize common options via environment variables before calling
 ```bash
 export NUM_EPOCH=40
 export HF_TOKEN="<your huggingface token>"
+export HF_REPO_TYPE=dataset  # optional, defaults to "dataset"
 sbatch scripts/tropical_cproute_job.sh
 ```
+
+> **Note:** Accept the usage conditions of the `Cainiao-AI/LaDe-P` dataset on
+> Hugging Face and provide a valid `HF_TOKEN` before running the download
+> script; otherwise the hub will respond with authentication errors.
 
 The dataset download script accepts additional parameters (repository id,
 prefix, or archive filename) through the batch script variables, allowing you to

--- a/route_prediction/scripts/download_pickup_dataset.py
+++ b/route_prediction/scripts/download_pickup_dataset.py
@@ -41,6 +41,7 @@ def _download_file(
     filename: str,
     output_dir: Path,
     token: str | None,
+    repo_type: str,
 ) -> Path:
     """Download ``filename`` from ``repo_id`` and return the local file path."""
 
@@ -49,8 +50,8 @@ def _download_file(
         repo_id=repo_id,
         filename=filename,
         local_dir=output_dir,
-        local_dir_use_symlinks=False,
         token=token,
+        repo_type=repo_type,
     )
     return Path(downloaded)
 
@@ -85,6 +86,12 @@ def main() -> None:
         "--repo-prefix",
         default="route_prediction/dataset",
         help="Repository sub-directory that stores the dataset artifacts.",
+    )
+    parser.add_argument(
+        "--repo-type",
+        default="dataset",
+        choices=("model", "dataset", "space"),
+        help="Hugging Face repository type that hosts the dataset artifacts.",
     )
     parser.add_argument(
         "--dataset",
@@ -131,7 +138,13 @@ def main() -> None:
             continue
         print(f"[download] Fetching {remote_file} from {args.repo_id}...")
         try:
-            _download_file(args.repo_id, remote_file, output_dir, args.token)
+            _download_file(
+                args.repo_id,
+                remote_file,
+                output_dir,
+                args.token,
+                args.repo_type,
+            )
         except HfHubHTTPError as err:
             print(
                 f"[download] Unable to fetch split '{split}' directly ({err}). "
@@ -148,7 +161,13 @@ def main() -> None:
     for archive in archive_paths:
         print(f"[download] Attempting archive download: {archive}")
         try:
-            archive_path = _download_file(args.repo_id, archive, output_dir, args.token)
+            archive_path = _download_file(
+                args.repo_id,
+                archive,
+                output_dir,
+                args.token,
+                args.repo_type,
+            )
         except HfHubHTTPError as err:
             print(f"[download] Archive {archive} unavailable ({err}).")
             continue

--- a/route_prediction/scripts/tropical_cproute_job.sh
+++ b/route_prediction/scripts/tropical_cproute_job.sh
@@ -26,6 +26,7 @@ PYTHON_BIN=${PYTHON_BIN:-python3}
 DATASET_NAME=${DATASET_NAME:-pickup_yt_0614_dataset_change}
 HF_REPO_ID=${HF_REPO_ID:-Cainiao-AI/LaDe-P}
 HF_REPO_PREFIX=${HF_REPO_PREFIX:-route_prediction/dataset}
+HF_REPO_TYPE=${HF_REPO_TYPE:-dataset}
 BATCH_SIZE=${BATCH_SIZE:-64}
 NUM_EPOCH=${NUM_EPOCH:-30}
 HIDDEN_SIZE=${HIDDEN_SIZE:-128}
@@ -61,7 +62,8 @@ if [[ "${SKIP_DATA_DOWNLOAD:-0}" != "1" ]]; then
         --dataset "$DATASET_NAME" \
         --output-dir "$DATASET_DIR" \
         --repo-id "$HF_REPO_ID" \
-        --repo-prefix "$HF_REPO_PREFIX"
+        --repo-prefix "$HF_REPO_PREFIX" \
+        --repo-type "$HF_REPO_TYPE"
 else
     echo "[$(date)] Skipping dataset download as requested."
 fi


### PR DESCRIPTION
## Summary
- allow `download_pickup_dataset.py` to specify the Hugging Face repo type and default it to `dataset`
- propagate the repo type option through `tropical_cproute_job.sh`
- document the dataset download requirements and configuration in the route prediction README

## Testing
- `python route_prediction/scripts/download_pickup_dataset.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c9765b6b488323b387e7a321cc3c73